### PR TITLE
Fix filename for huddraw.lua in cl_init.lua (#2140)

### DIFF
--- a/lua/entities/gmod_wire_egp_hud/cl_init.lua
+++ b/lua/entities/gmod_wire_egp_hud/cl_init.lua
@@ -1,5 +1,5 @@
 include('shared.lua')
-include("HUDDraw.lua")
+include('huddraw.lua')
 
 ENT.gmod_wire_egp_hud = true
 


### PR DESCRIPTION
"The wrong name broke the EGP HUD for me."